### PR TITLE
Document correct URLs for auth

### DIFF
--- a/scenarios/authenticating/index.md
+++ b/scenarios/authenticating/index.md
@@ -8,8 +8,8 @@ Most read endpoints are open. However, we encourage clients to request follow th
 Requests without a access token may be subject to throttling if the server is under high load.
 
 Authentication servers:
-* Test: nva-test.auth.eu-west-1.amazoncognito.com
-* Production: nva-prod.auth.eu-west-1.amazoncognito.com
+* Test: nva-test-ext.auth.eu-west-1.amazoncognito.com
+* Production: nva-prod-ext.auth.eu-west-1.amazoncognito.com
 
 ## Obtaining an access token
 ```mermaid


### PR DESCRIPTION
I assume these URLs were for an earlier version or something? I got credentials to use, and it will (at least for me) only work with the URLs in this PR, and not the ones currently in the docs.

An additional clue to whether or not this is the wrong one, can be found in [the swagger docs](https://swagger-ui.nva.unit.no/#/) where the URL nva-prod-ext.auth.eu-west-1.amazoncognito.com is also used.